### PR TITLE
Update b2luigi documentation website

### DIFF
--- a/software.bib
+++ b/software.bib
@@ -16,6 +16,14 @@
     url = {https://b2luigi.belle2.org/}
 }
 
+@software{b2luigi_GitHub ,
+    author = {Heidelbach, A. and Eppelt, J. and Eliachevitch, M. and Braun, N. and others}
+    title = {belle2/b2luigi},
+    publisher = {Zenodo},
+    doi = {10.5281/zenodo.10853220},
+    url = {https://doi.org/10.5281/zenodo.10853220},
+}
+
 @online{boost_histogram_docs,
     title = {boost-histogram package documentation},
     url = {https://boost-histogram.readthedocs.io/}

--- a/software.bib
+++ b/software.bib
@@ -13,7 +13,7 @@
 
 @online{b2luigi_docs,
     title = {b2luigi package documentation},
-    url = {https://b2luigi.readthedocs.io/}
+    url = {https://b2luigi.belle2.org/}
 }
 
 @online{boost_histogram_docs,


### PR DESCRIPTION
We configured the Red the Docs website to redirect to b2luigi.belle2.org, so I suggest to use directly this URL.

Let me also use this opportunity for few questions:
- we have an entry on Zenodo for b2luigi (see https://zenodo.org/records/15773902): is it fine to add it here?
- which software do you like/want to be included in this repository? In Belle II we have some open source software (as you know), and some publications related to it (see https://software.belle2.org/development/sphinx/framework/doc/atend-publications.html). Are these something that you would like to have included here?
- related to the previous point: there are a lot of packages widely used by the HEP community, like MC generators. If needed, I can prepare the list of references of what we use in Belle II.