### PR TITLE
Fix BibTeX syntax errors in b2luigi_GitHub entry

### DIFF
--- a/software.bib
+++ b/software.bib
@@ -16,8 +16,8 @@
     url = {https://b2luigi.belle2.org/}
 }
 
-@software{b2luigi_GitHub ,
-    author = {Heidelbach, A. and Eppelt, J. and Eliachevitch, M. and Braun, N. and others}
+@software{b2luigi_GitHub,
+    author = {Heidelbach, A. and Eppelt, J. and Eliachevitch, M. and Braun, N. and others},
     title = {belle2/b2luigi},
     publisher = {Zenodo},
     doi = {10.5281/zenodo.10853220},


### PR DESCRIPTION
Remove extra space in entry key
Add missing comma after author field