### PR TITLE
Fix alphabetical order of entries in software.bib

### DIFF
--- a/software.bib
+++ b/software.bib
@@ -112,11 +112,6 @@
     url = {https://root.cern/}
 }
 
-@online{Vector_docs,
-    title = {Vector package documentation},
-    url = {https://vector.readthedocs.io/}
-}
-
 @online{Snakemake,
     title = {Snakemake package documentation},
     url = {https://Snakemake.readthedocs.io/}
@@ -130,6 +125,11 @@
 @online{Uproot_docs,
     title = {Uproot package documentation},
     url = {https://uproot.readthedocs.io/}
+}
+
+@online{Vector_docs,
+    title = {Vector package documentation},
+    url = {https://vector.readthedocs.io/}
 }
 
 @online{Zarr_docs,


### PR DESCRIPTION
Moved Snakemake and Vector_docs to correct positions:
- Snakemake now appears after ROOT_site (S before U/V)
- Vector_docs now appears after Uproot_docs (V after U)