### PR TITLE
Fix multiple BibTeX issues in software.bib and events_hep.bib

### DIFF
--- a/events_hep.bib
+++ b/events_hep.bib
@@ -9,7 +9,7 @@
 % PyHEP workshops
 % ---------------
 @online{PyHEP2025dev,
-    title = {PyHEP.dev 2025 - "Python in HEP" Developer's Workshop (14-7 July 2025, Seattle, Washington, USA)},
+    title = {PyHEP.dev 2025 - "Python in HEP" Developer's Workshop (14-17 July 2025, Seattle, Washington, USA)},
     url = {https://indico.cern.ch/e/PyHEP2025.dev}
 }
 

--- a/software.bib
+++ b/software.bib
@@ -16,8 +16,8 @@
     url = {https://b2luigi.belle2.org/}
 }
 
-@software{b2luigi_GitHub ,
-    author = {Heidelbach, A. and Eppelt, J. and Eliachevitch, M. and Braun, N. and others}
+@software{b2luigi_GitHub,
+    author = {Heidelbach, A. and Eppelt, J. and Eliachevitch, M. and Braun, N. and others},
     title = {belle2/b2luigi},
     publisher = {Zenodo},
     doi = {10.5281/zenodo.10853220},
@@ -55,7 +55,7 @@
 }
 
 @online{HistFitter,
-    title = {HistxFitter A software framework for statistical data analysis},
+    title = {HistFitter: A software framework for statistical data analysis},
     url = {https://histfitter.github.io}
 }
 
@@ -112,11 +112,6 @@
     url = {https://root.cern/}
 }
 
-@online{Vector_docs,
-    title = {Vector package documentation},
-    url = {https://vector.readthedocs.io/}
-}
-
 @online{Snakemake,
     title = {Snakemake package documentation},
     url = {https://Snakemake.readthedocs.io/}
@@ -130,6 +125,11 @@
 @online{Uproot_docs,
     title = {Uproot package documentation},
     url = {https://uproot.readthedocs.io/}
+}
+
+@online{Vector_docs,
+    title = {Vector package documentation},
+    url = {https://vector.readthedocs.io/}
 }
 
 @online{Zarr_docs,


### PR DESCRIPTION
This commit combines the following fixes:
- Fix BibTeX syntax errors in b2luigi_GitHub entry (removed extra space, added missing comma)
- Fix typo in HistFitter entry title (HistxFitter -> HistFitter:)
- Fix date typo in PyHEP2025dev entry (14-7 -> 14-17 July)
- Fix alphabetical order of entries in software.bib (moved Vector_docs to correct position)